### PR TITLE
Fix Bug Farm FeedBack

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -44,6 +44,7 @@ import { SlotsPlantModule } from '@modules/slots-plant/slots-plant.module';
 import { UserClanStatModule } from '@modules/user-clan-stat/user-clan-stat.module';
 import { ClanActivityModule } from './modules/clan-activity/clan-activity.module';
 import { GameConfigModule } from './modules/admin/game-config/game-config.module';
+import { NumberRarityModule } from '@modules/number-rarity/number-rarity.module';
 
 @Module({
   imports: [
@@ -98,6 +99,7 @@ import { GameConfigModule } from './modules/admin/game-config/game-config.module
     UserClanStatModule,
     ClanActivityModule,
     GameConfigModule,
+    NumberRarityModule,
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,6 +43,7 @@ import { ClanWarehouseModule } from '@modules/clan-warehouse/clan-warehouse.modu
 import { SlotsPlantModule } from '@modules/slots-plant/slots-plant.module';
 import { UserClanStatModule } from '@modules/user-clan-stat/user-clan-stat.module';
 import { ClanActivityModule } from './modules/clan-activity/clan-activity.module';
+import { GameConfigModule } from './modules/admin/game-config/game-config.module';
 
 @Module({
   imports: [
@@ -96,6 +97,7 @@ import { ClanActivityModule } from './modules/clan-activity/clan-activity.module
     SlotsPlantModule,
     UserClanStatModule,
     ClanActivityModule,
+    GameConfigModule,
   ],
 })
 export class AppModule {}

--- a/src/constant/farm.constant.ts
+++ b/src/constant/farm.constant.ts
@@ -12,7 +12,7 @@ export const CLAN_WAREHOUSE = {
 
 export const FARM_CONFIG = {
   HARVEST: {
-    ENABLE_LIMIT: true,
+    ENABLE_LIMIT: false,
     UNLIMITED: -1,
     DELAY_MS: 10000,
     INTERRUPT_RATE: 0.2,
@@ -30,14 +30,14 @@ export const FARM_CONFIG = {
     },
   },
   PLANT: {
-    ENABLE_LIMIT: true,
+    ENABLE_LIMIT: false,
     UNLIMITED: -1,
     MAX_HARVEST: 100,
     RESET_PLANT_HOURS: 24,
     get DEATH_MS() {
       return this.RESET_PLANT_HOURS * 60 * 60 * 1000; // convert giờ -> ms
     },
-    FORMULAS: {
+    FORMULA: {
       growTimeSeconds: (grow_time_minutes: number) => grow_time_minutes * 60,
       harvestPoint: (grow_time_minutes: number) =>
         Math.round(grow_time_minutes * 1.5),

--- a/src/constant/farm.constant.ts
+++ b/src/constant/farm.constant.ts
@@ -12,6 +12,8 @@ export const CLAN_WAREHOUSE = {
 
 export const FARM_CONFIG = {
   HARVEST: {
+    ENABLE_LIMIT: true,
+    UNLIMITED: -1,
     DELAY_MS: 10000,
     INTERRUPT_RATE: 0.2,
     MAX_HARVEST: 100,
@@ -28,7 +30,9 @@ export const FARM_CONFIG = {
     },
   },
   PLANT: {
-    MAX_HARVEST: 10,
+    ENABLE_LIMIT: true,
+    UNLIMITED: -1,
+    MAX_HARVEST: 100,
     RESET_PLANT_HOURS: 24,
     get DEATH_MS() {
       return this.RESET_PLANT_HOURS * 60 * 60 * 1000; // convert giờ -> ms

--- a/src/constant/game-config.keys.ts
+++ b/src/constant/game-config.keys.ts
@@ -1,0 +1,6 @@
+export const GAME_CONFIG_KEYS = {
+  FARM: 'farm.config',
+} as const;
+
+export type GameConfigKey =
+  (typeof GAME_CONFIG_KEYS)[keyof typeof GAME_CONFIG_KEYS];

--- a/src/migrations/1761275702923-seed-data-plant.ts
+++ b/src/migrations/1761275702923-seed-data-plant.ts
@@ -59,9 +59,9 @@ export class SeedDataPlant1761275702923 implements MigrationInterface {
     ];
 
     for (const plant of basePlants) {
-      const grow_time_seconds = FARM_CONFIG.PLANT.FORMULAS.growTimeSeconds(plant.grow_time_minutes);
-      const harvest_point = FARM_CONFIG.PLANT.FORMULAS.harvestPoint(plant.grow_time_minutes);
-      const buy_price = FARM_CONFIG.PLANT.FORMULAS.buyPrice(plant.grow_time_minutes);
+      const grow_time_seconds = FARM_CONFIG.PLANT.FORMULA.growTimeSeconds(plant.grow_time_minutes);
+      const harvest_point = FARM_CONFIG.PLANT.FORMULA.harvestPoint(plant.grow_time_minutes);
+      const buy_price = FARM_CONFIG.PLANT.FORMULA.buyPrice(plant.grow_time_minutes);
 
       await queryRunner.query(`
         INSERT INTO plants (name, grow_time, harvest_point, buy_price, description, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, NOW(), NOW()) ON CONFLICT (name) DO UPDATE SET grow_time = EXCLUDED.grow_time, harvest_point = EXCLUDED.harvest_point, buy_price = EXCLUDED.buy_price, description = EXCLUDED.description, updated_at = NOW();

--- a/src/migrations/1766128879673-remove-vice-leader-unique.ts
+++ b/src/migrations/1766128879673-remove-vice-leader-unique.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveViceLeaderUnique1766128879673 implements MigrationInterface {
+    name = 'RemoveViceLeaderUnique1766128879673';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+      DROP INDEX IF EXISTS "public"."UQ_clan_vice_leader";
+    `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_clan_vice_leader"
+      ON "user" ("clan_id")
+      WHERE "clan_role" = 'vice_leader'
+        AND "clan_id" IS NOT NULL;
+    `);
+    }
+}

--- a/src/migrations/1766381392436-create-table-game-configs.ts
+++ b/src/migrations/1766381392436-create-table-game-configs.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateTableGameConfigs1766381392436 implements MigrationInterface {
+    name = 'CreateTableGameConfigs1766381392436'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "game_configs" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying, "key" character varying NOT NULL, "value" jsonb NOT NULL, "enabled" boolean NOT NULL DEFAULT true, "version" integer NOT NULL DEFAULT '1', "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_944f485adb861a0baee12def6f4" UNIQUE ("key"), CONSTRAINT "PK_game_configs_id" PRIMARY KEY ("id"))`);
+        }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "game_configs"`);
+        }
+
+}

--- a/src/migrations/1766387807843-seed-farm-configs-into-game-configs.ts
+++ b/src/migrations/1766387807843-seed-farm-configs-into-game-configs.ts
@@ -1,0 +1,20 @@
+import { FARM_CONFIG } from '@constant/farm.constant';
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SeedFarmConfigsIntoGameConfigs1766387807843
+  implements MigrationInterface
+{
+  name = 'SeedFarmConfigsIntoGameConfigs1766387807843';
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+      INSERT INTO game_configs (key, name, value)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (key) DO NOTHING
+    `,
+      ['farm.config', 'Farm config', JSON.stringify(FARM_CONFIG)],
+    );
+  }
+
+  async down(): Promise<void> {}
+}

--- a/src/migrations/1766392353801-remove-harvest-limit-columns.ts
+++ b/src/migrations/1766392353801-remove-harvest-limit-columns.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RemoveHarvestLimitColumns1766392353801 implements MigrationInterface {
+  name = 'RemoveHarvestLimitColumns1766392353801';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user_clan_stats"
+      DROP COLUMN IF EXISTS "harvest_count";
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "user_clan_stats"
+      DROP COLUMN IF EXISTS "harvest_interrupt_count";
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user_clan_stats"
+      ADD COLUMN "harvest_count" integer DEFAULT 100;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "user_clan_stats"
+      ADD COLUMN "harvest_interrupt_count" integer DEFAULT 100;
+    `);
+  }
+}

--- a/src/migrations/1766450974651-remove-harvest-count-max-from-slot-plants.ts
+++ b/src/migrations/1766450974651-remove-harvest-count-max-from-slot-plants.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveHarvestCountMaxFromSlotPlants1766450974651
+  implements MigrationInterface
+{
+  name = 'RemoveHarvestCountMaxFromSlotPlants1766450974651';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE slot_plants
+        DROP COLUMN harvest_count_max`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE slot_plants
+        ADD COLUMN harvest_count_max INT NOT NULL DEFAULT 100`);
+  }
+}

--- a/src/migrations/1766481809586-add-number-rarity.ts
+++ b/src/migrations/1766481809586-add-number-rarity.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddNumberRarity1766481809586 implements MigrationInterface {
+    name = 'AddNumberRarity1766481809586'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "number_rarity" ("created_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "id" uuid NOT NULL DEFAULT uuid_generate_v4(), "room_code" character varying(255) NOT NULL, "common_number" integer NOT NULL DEFAULT '6', "rare_number" integer NOT NULL DEFAULT '3', "epic_number" integer NOT NULL DEFAULT '1', "legendary_number" integer NOT NULL DEFAULT '0', CONSTRAINT "PK_2a6ca7f3e62ed648a08627b0090" PRIMARY KEY ("id")), CONSTRAINT "UQ_number_rarity_room_code" UNIQUE ("room_code")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "number_rarity"`);
+    }
+
+}

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -12,6 +12,8 @@ import { RewardManagementModule } from './reward/reward.module';
 import { RewardManagementController } from './reward/reward.controller';
 import { QuestManagementModule } from './quest/quest.module';
 import { QuestManagementController } from './quest/quest.controller';
+import { AdminNumberRarityModule } from '@modules/admin/number-rarity/number-rarity.module';
+import { AdminNumberRarityController } from '@modules/admin/number-rarity/number-rarity.controller';
 
 @Module({
   imports: [
@@ -22,6 +24,7 @@ import { QuestManagementController } from './quest/quest.controller';
     AdminPetPlayersModule,
     RewardManagementModule,
     QuestManagementModule,
+    AdminNumberRarityModule,
   ],
   controllers: [
     TransactionsController,
@@ -30,6 +33,7 @@ import { QuestManagementController } from './quest/quest.controller';
     AdminPetPlayersController,
     RewardManagementController,
     QuestManagementController,
+    AdminNumberRarityController,
   ],
 })
 export class AdminModule {}

--- a/src/modules/admin/game-config/dto/game-config.dto.ts
+++ b/src/modules/admin/game-config/dto/game-config.dto.ts
@@ -1,0 +1,23 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsObject, IsOptional } from 'class-validator';
+
+export class UpdateGameConfigDto {
+  @ApiPropertyOptional({
+    description: 'Partial config value',
+    example: {
+      PLANT: { ENABLE_LIMIT: false },
+      HARVEST: { ENABLE_LIMIT: false },
+    },
+  })
+  @IsOptional()
+  @IsObject()
+  value?: Record<string, any>;
+
+  @ApiPropertyOptional({
+    description: 'Enable / disable config',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/src/modules/admin/game-config/entity/game-config.entity.ts
+++ b/src/modules/admin/game-config/entity/game-config.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity({ name: 'game_configs' })
+export class GameConfigEntity {
+  @PrimaryGeneratedColumn('uuid', { primaryKeyConstraintName: 'PK_game_configs_id' })
+  id: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  name: string | null;
+
+  @Column({ unique: true })
+  key: string;
+
+  @Column({ type: 'jsonb' })
+  value: any;
+
+  @Column({ default: true })
+  enabled: boolean;
+
+  @Column({ default: 1 })
+  version: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/src/modules/admin/game-config/game-config.controller.ts
+++ b/src/modules/admin/game-config/game-config.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Get, Param, Put } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
+import { ClsService } from 'nestjs-cls';
+import { gameConfigService } from './game-config.service';
+import { UpdateGameConfigDto } from './dto/game-config.dto';
+import { RequireAdmin } from '@libs/decorator';
+
+@ApiBearerAuth()
+@ApiTags('GameConfig')
+@RequireAdmin()
+@Controller('game-configs')
+export class GameConfigController {
+  constructor(
+    private readonly gameConfigService: gameConfigService,
+    private readonly clsService: ClsService,
+  ) {}
+
+  @Get()
+  findAll() {
+    return this.gameConfigService.findAll();
+  }
+
+  @Put(':key')
+  @ApiBody({ type: UpdateGameConfigDto })
+  async update(
+    @Param('key') key: string,
+    @Body() body: UpdateGameConfigDto,
+  ) {
+    await this.gameConfigService.update(key, body);
+    return { success: true };
+  }
+}

--- a/src/modules/admin/game-config/game-config.module.ts
+++ b/src/modules/admin/game-config/game-config.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ClsModule } from 'nestjs-cls';
+import { GameConfigEntity } from './entity/game-config.entity';
+import { GameConfigController } from './game-config.controller';
+import { gameConfigService } from './game-config.service';
+import { GameConfigStore } from './game-config.store';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([GameConfigEntity]), ClsModule],
+  providers: [gameConfigService, GameConfigStore],
+  controllers: [GameConfigController],
+  exports: [GameConfigStore, gameConfigService],
+})
+export class GameConfigModule {}

--- a/src/modules/admin/game-config/game-config.service.ts
+++ b/src/modules/admin/game-config/game-config.service.ts
@@ -1,0 +1,61 @@
+import { BadRequestException, Injectable, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GameConfigEntity } from './entity/game-config.entity';
+import { GameConfigStore } from './game-config.store';
+import { GameConfigKey } from '@constant/game-config.keys';
+import { merge } from 'lodash';
+
+@Injectable()
+export class gameConfigService implements OnModuleInit {
+  constructor(
+    @InjectRepository(GameConfigEntity)
+    private readonly repo: Repository<GameConfigEntity>,
+    private readonly store: GameConfigStore,
+  ) {}
+  async onModuleInit() {
+    await this.loadAll();
+  }
+  async loadAll() {
+    const rows = await this.repo.find({
+      where: { enabled: true },
+    });
+
+    this.store.clear();
+
+    for (const row of rows) {
+      this.store.set(row.key as GameConfigKey, row.value);
+    }
+
+    console.log(`[Config] Loaded ${rows.length} configs`);
+  }
+
+  async reload() {
+    await this.loadAll();
+  }
+
+  async findAll() {
+    return this.repo.find({ order: { created_at: 'ASC' } });
+  }
+
+  async update(
+    key: string,
+    dto: { value?: any; enabled?: boolean },
+  ) {
+    const config = await this.repo.findOne({ where: { key } });
+    if (!config) {
+      throw new BadRequestException('Config not found');
+    }
+
+    if (dto.value) {
+      config.value = merge({}, config.value, dto.value);
+    }
+
+    if (dto.enabled !== undefined) {
+      config.enabled = dto.enabled;
+    }
+
+    await this.repo.save(config);
+    await this.reload();
+  }
+}

--- a/src/modules/admin/game-config/game-config.store.ts
+++ b/src/modules/admin/game-config/game-config.store.ts
@@ -1,0 +1,23 @@
+import { GameConfigKey } from "@constant/game-config.keys";
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class GameConfigStore {
+  private readonly store = new Map<GameConfigKey, any>();
+
+  set<T>(key: GameConfigKey, value: T) {
+    this.store.set(key, value);
+  }
+
+  get<T>(key: GameConfigKey): T | null {
+    return this.store.get(key) ?? null;
+  }
+
+  has(key: GameConfigKey): boolean {
+    return this.store.has(key);
+  }
+
+  clear() {
+    this.store.clear();
+  }
+}

--- a/src/modules/admin/number-rarity/dto/number-rarity.dto.ts
+++ b/src/modules/admin/number-rarity/dto/number-rarity.dto.ts
@@ -1,0 +1,53 @@
+import { IsValidRoomCode } from "@libs/decorator";
+import { ApiProperty, PartialType } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsNumber, IsString } from "class-validator";
+
+
+export class CreateNumberRarityDto {
+  @ApiProperty({
+    description: 'Room code where the pet is located.',
+    example: 'sg',
+  })
+  @IsString()
+  @IsValidRoomCode()
+  room_code: string;
+
+  @ApiProperty({
+    description: 'Number of common pets to fill',
+    type: Number,
+    default: 6,
+  })
+  @IsNumber()
+  @Type(() => Number)
+  common_number: number;
+
+  @ApiProperty({
+    description: 'Number of rare pets to fill',
+    type: Number,
+    default: 3,
+  })
+  @IsNumber()
+  @Type(() => Number)
+  rare_number: number;
+
+  @ApiProperty({
+    description: 'Number of epic pets to fill',
+    type: Number,
+    default: 1,
+  })
+  @IsNumber()
+  @Type(() => Number)
+  epic_number: number;
+
+  @ApiProperty({
+    description: 'Number of legendary pets to fill',
+    type: Number,
+    default: 0,
+  })
+  @IsNumber()
+  @Type(() => Number)
+  legendary_number: number;
+}
+
+export class UpdateNumberRarityDto extends PartialType(CreateNumberRarityDto) {}

--- a/src/modules/admin/number-rarity/number-rarity.controller.ts
+++ b/src/modules/admin/number-rarity/number-rarity.controller.ts
@@ -5,8 +5,7 @@ import {
   Post,
   Put,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
-import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { RequireAdmin } from '@libs/decorator';
 import { AdminNumberRarityService } from '@modules/admin/number-rarity/number-rarity.service';
 import { CreateNumberRarityDto, UpdateNumberRarityDto } from '@modules/admin/number-rarity/dto/number-rarity.dto';
@@ -22,20 +21,23 @@ export class AdminNumberRarityController {
 
   @Post()
   @RequireAdmin()
-  @ApiOperation({ summary: 'Create number rarity config' })
-  create(
-    @Body() dto: CreateNumberRarityDto,
-  ): Promise<NumberRarityEntity> {
+  @ApiOperation({
+    summary: 'Create number rarity config'
+  })
+  create(@Body() dto: CreateNumberRarityDto) {
     return this.service.createNumberRarity(dto);
   }
 
   @Put(':roomCode')
   @RequireAdmin()
-  @ApiOperation({ summary: 'Update number rarity by room code' })
-  update(
-    @Param('roomCode') roomCode: string,
-    @Body() dto: UpdateNumberRarityDto,
-  ): Promise<NumberRarityEntity> {
+  @ApiParam({
+    name: 'roomCode',
+    example: 'sg',
+  })
+  @ApiOperation({
+    summary: 'Update number rarity by room code'
+  })
+  update(@Param('roomCode') roomCode: string, @Body() dto: UpdateNumberRarityDto) {
     return this.service.updateNumberRarity(roomCode, dto);
   }
 }

--- a/src/modules/admin/number-rarity/number-rarity.controller.ts
+++ b/src/modules/admin/number-rarity/number-rarity.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Body,
+  Controller,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
+import { RequireAdmin } from '@libs/decorator';
+import { AdminNumberRarityService } from '@modules/admin/number-rarity/number-rarity.service';
+import { CreateNumberRarityDto, UpdateNumberRarityDto } from '@modules/admin/number-rarity/dto/number-rarity.dto';
+
+@ApiBearerAuth()
+@RequireAdmin()
+@Controller('number-rarity')
+@ApiTags('Admin - Number Rarity')
+export class AdminNumberRarityController {
+  constructor(
+    private readonly service: AdminNumberRarityService,
+  ) {}
+
+  @Post()
+  @RequireAdmin()
+  @ApiOperation({ summary: 'Create number rarity config' })
+  create(
+    @Body() dto: CreateNumberRarityDto,
+  ): Promise<NumberRarityEntity> {
+    return this.service.createNumberRarity(dto);
+  }
+
+  @Put(':roomCode')
+  @RequireAdmin()
+  @ApiOperation({ summary: 'Update number rarity by room code' })
+  update(
+    @Param('roomCode') roomCode: string,
+    @Body() dto: UpdateNumberRarityDto,
+  ): Promise<NumberRarityEntity> {
+    return this.service.updateNumberRarity(roomCode, dto);
+  }
+}

--- a/src/modules/admin/number-rarity/number-rarity.module.ts
+++ b/src/modules/admin/number-rarity/number-rarity.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminNumberRarityController } from './number-rarity.controller';
+import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
+import { PetSpawnCronJob } from '@modules/admin/number-rarity/pet-players.cronjob';
+import { AdminNumberRarityService } from '@modules/admin/number-rarity/number-rarity.service';
+import { NumberRarityModule } from '@modules/number-rarity/number-rarity.module';
+import { PetPlayersModule } from '@modules/pet-players/pet-players.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([NumberRarityEntity]),
+    NumberRarityModule,
+    PetPlayersModule,
+  ],
+  providers: [AdminNumberRarityService, PetSpawnCronJob],
+  exports: [AdminNumberRarityService],
+})
+export class AdminNumberRarityModule {}

--- a/src/modules/admin/number-rarity/number-rarity.service.ts
+++ b/src/modules/admin/number-rarity/number-rarity.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EntityManager, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
 import { BaseService } from '@libs/base/base.service';
 import { NumberRarityService } from '@modules/number-rarity/number-rarity.service';
@@ -11,7 +11,6 @@ export class AdminNumberRarityService extends BaseService<NumberRarityEntity> {
   constructor(
     @InjectRepository(NumberRarityEntity)
     private readonly numberRarityRepository: Repository<NumberRarityEntity>,
-    private manager: EntityManager,
     private readonly numberRarityService: NumberRarityService,
   ) {
     super(numberRarityRepository, NumberRarityEntity.name);

--- a/src/modules/admin/number-rarity/number-rarity.service.ts
+++ b/src/modules/admin/number-rarity/number-rarity.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
+import { BaseService } from '@libs/base/base.service';
+import { NumberRarityService } from '@modules/number-rarity/number-rarity.service';
+import { CreateNumberRarityDto, UpdateNumberRarityDto } from '@modules/admin/number-rarity/dto/number-rarity.dto';
+
+@Injectable()
+export class AdminNumberRarityService extends BaseService<NumberRarityEntity> {
+  constructor(
+    @InjectRepository(NumberRarityEntity)
+    private readonly numberRarityRepository: Repository<NumberRarityEntity>,
+    private manager: EntityManager,
+    private readonly numberRarityService: NumberRarityService,
+  ) {
+    super(numberRarityRepository, NumberRarityEntity.name);
+  }
+
+  async createNumberRarity(dto: CreateNumberRarityDto) {
+    return this.numberRarityService.createNumberRarity(dto);
+  }
+
+  async updateNumberRarity(roomCode: string, dto: UpdateNumberRarityDto) {
+    return this.numberRarityService.updateNumberRarity(roomCode, dto);
+  }
+}

--- a/src/modules/admin/number-rarity/pet-players.cronjob.ts
+++ b/src/modules/admin/number-rarity/pet-players.cronjob.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PetPlayersService } from '@modules/pet-players/pet-players.service';
+import { NumberRarityService } from '@modules/number-rarity/number-rarity.service';
+
+@Injectable()
+export class PetSpawnCronJob {
+  private readonly logger = new Logger(PetSpawnCronJob.name);
+
+  constructor(
+    private readonly petPlayersService: PetPlayersService,
+    private readonly numberRarityService: NumberRarityService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async checkAndFillPets() {
+    try {
+      this.logger.log('Start check & fill pets');
+      const numberRarities = await this.numberRarityService.findAll();
+      const allRooms = numberRarities.map(nr => nr.room_code);
+
+      for (const room_code of allRooms) {
+        const commonNumber = numberRarities.find(nr => nr.room_code === room_code)?.common_number || 6;
+        const rareNumber = numberRarities.find(nr => nr.room_code === room_code)?.rare_number || 3;
+        const epicNumber = numberRarities.find(nr => nr.room_code === room_code)?.epic_number || 2;
+        const legendaryNumber = numberRarities.find(nr => nr.room_code === room_code)?.legendary_number || 0;
+        await this.petPlayersService.fillMissingPetsByRoom(room_code, commonNumber, rareNumber, epicNumber, legendaryNumber);
+        this.logger.log(`Room ${room_code} checked`);
+      }
+
+      this.logger.log('Finished check & fill pets');
+    } catch (error) {
+      this.logger.error('Error during check & fill pets', error);
+    }
+  }
+}

--- a/src/modules/admin/pet-players/pet-players.controller.ts
+++ b/src/modules/admin/pet-players/pet-players.controller.ts
@@ -44,24 +44,19 @@ export class AdminPetPlayersController {
     return await this.adminPetPlayersService.createPetPlayers(pet, quantity);
   }
 
-   @Post('fill-missing/:room_code')
+  @Post('fill-missing/:room_code')
   @RequireAdmin()
-  @ApiOperation({
-    summary: 'Fill missing pets in a room',
-  })
   @ApiParam({
     name: 'room_code',
     example: 'sg',
   })
+  @ApiOperation({
+    summary: 'Fill missing pets in a room',
+  })
   async fillMissingPetsByRoom(
     @Param('room_code') room_code: string,
   ) {
-    await this.adminPetPlayersService.fillMissingPetsByRoom(room_code);
-
-    return {
-      success: true,
-      message: `Filled missing pets for room ${room_code}`,
-    };
+    return await this.adminPetPlayersService.fillMissingPetsByRoom(room_code);
   }
 
   @Get(':pet_player_id')

--- a/src/modules/admin/pet-players/pet-players.controller.ts
+++ b/src/modules/admin/pet-players/pet-players.controller.ts
@@ -44,6 +44,26 @@ export class AdminPetPlayersController {
     return await this.adminPetPlayersService.createPetPlayers(pet, quantity);
   }
 
+   @Post('fill-missing/:room_code')
+  @RequireAdmin()
+  @ApiOperation({
+    summary: 'Fill missing pets in a room',
+  })
+  @ApiParam({
+    name: 'room_code',
+    example: 'sg',
+  })
+  async fillMissingPetsByRoom(
+    @Param('room_code') room_code: string,
+  ) {
+    await this.adminPetPlayersService.fillMissingPetsByRoom(room_code);
+
+    return {
+      success: true,
+      message: `Filled missing pets for room ${room_code}`,
+    };
+  }
+
   @Get(':pet_player_id')
   @ApiParam({
     name: 'pet_player_id',

--- a/src/modules/admin/pet-players/pet-players.module.ts
+++ b/src/modules/admin/pet-players/pet-players.module.ts
@@ -7,6 +7,7 @@ import { ClsModule } from 'nestjs-cls';
 import { AdminPetPlayersService } from './pet-players.service';
 import { PetPlayersModule } from '@modules/pet-players/pet-players.module';
 import { UserModule } from '@modules/user/user.module';
+import { NumberRarityModule } from '@modules/number-rarity/number-rarity.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { UserModule } from '@modules/user/user.module';
     PetSkillsModule,
     PetPlayersModule,
     UserModule,
+    NumberRarityModule,
   ],
   providers: [AdminPetPlayersService],
   exports: [AdminPetPlayersService],

--- a/src/modules/admin/pet-players/pet-players.service.ts
+++ b/src/modules/admin/pet-players/pet-players.service.ts
@@ -20,6 +20,7 @@ import {
   SpawnPetPlayersDto,
   UpdatePetPlayersDto,
 } from './dto/pet-players.dto';
+import { NumberRarityService } from '@modules/number-rarity/number-rarity.service';
 
 @Injectable()
 export class AdminPetPlayersService extends BaseService<PetPlayersEntity> {
@@ -30,6 +31,7 @@ export class AdminPetPlayersService extends BaseService<PetPlayersEntity> {
     private readonly petsRepository: Repository<PetsEntity>,
     private readonly petPlayersService: PetPlayersService,
     private readonly userService: UserService,
+    private readonly numberRarityService: NumberRarityService,
     private manager: EntityManager,
   ) {
     super(petPlayersRepository, PetPlayersEntity.name);
@@ -150,6 +152,18 @@ export class AdminPetPlayersService extends BaseService<PetPlayersEntity> {
 
   async createPetPlayers(payload: Partial<SpawnPetPlayersDto>, quantity = 1) {
     return await this.petPlayersService.createPetPlayers(payload, quantity);
+  }
+
+  async fillMissingPetsByRoom(room_code: string) {
+    const room = await this.numberRarityService.findOne({ where: { room_code }, });
+    if (!room) throw new BadRequestException(`Room code ${room_code} not found`);
+
+    const common = room.common_number;
+    const rare = room.rare_number;
+    const epic = room.epic_number;
+    const legendary = room.legendary_number;
+
+    return await this.petPlayersService.fillMissingPetsByRoom(room_code, common, rare, epic, legendary);
   }
 
   async updatePetPlayers(

--- a/src/modules/clan-fund/clan-fund.service.ts
+++ b/src/modules/clan-fund/clan-fund.service.ts
@@ -230,15 +230,23 @@ export class ClanFundService {
         rank: amount > 0 ? currentRank++ : 0,
       };
     });
-    const leaders = rankedData.filter(
-      (u) =>
-        u.clan_role === ClanRole.LEADER || u.clan_role === ClanRole.VICE_LEADER,
-    );
-    const members = rankedData.filter(
-      (u) =>
-        u.clan_role !== ClanRole.LEADER && u.clan_role !== ClanRole.VICE_LEADER,
-    );
-    const finalList = [...leaders, ...members];
+    const leaders = rankedData
+      .filter((u) => u.clan_role === ClanRole.LEADER)
+      .sort((a, b) => a.rank - b.rank);
+
+    const viceLeaders = rankedData
+      .filter((u) => u.clan_role === ClanRole.VICE_LEADER)
+      .sort((a, b) => a.rank - b.rank);
+
+    const members = rankedData
+      .filter(
+        (u) =>
+          u.clan_role !== ClanRole.LEADER &&
+          u.clan_role !== ClanRole.VICE_LEADER,
+      )
+      .sort((a, b) => a.rank - b.rank);
+
+    const finalList = [...leaders, ...viceLeaders, ...members];
 
     const start = (page - 1) * limit;
     const end = start + limit;

--- a/src/modules/clan-request/clan-request.service.ts
+++ b/src/modules/clan-request/clan-request.service.ts
@@ -130,8 +130,6 @@ export class ClanRequestService extends BaseService<ClanRequestEntity> {
         clan_id: clan.id,
         total_score: 0,
         weekly_score: 0,
-        harvest_count: FARM_CONFIG.HARVEST.MAX_HARVEST,
-        harvest_interrupt_count: FARM_CONFIG.HARVEST.MAX_INTERRUPT,
         harvest_count_use: 0,
         harvest_interrupt_count_use: 0,
       });

--- a/src/modules/clan-warehouse/clan-warehouse.controller.ts
+++ b/src/modules/clan-warehouse/clan-warehouse.controller.ts
@@ -5,7 +5,7 @@ import { BuyPlantDto, SeedClanWarehouseDto } from './dto/clan-warehouse.dto';
 import { UserEntity } from '@modules/user/entity/user.entity';
 import { USER_TOKEN } from '@constant';
 import { ClsService } from 'nestjs-cls';
-import { RequireClanRoles } from '@libs/decorator';
+import { RequireAdmin, RequireClanRoles } from '@libs/decorator';
 
 @ApiBearerAuth()
 @ApiTags('Clan Warehouse')
@@ -31,6 +31,7 @@ export class ClanWarehouseController {
   }
 
   @Post('seed-plant-to-warehouse')
+  @RequireAdmin()
   @ApiOperation({ summary: 'Add item in warehouse for a clan' })
   async seedWarehouse(@Body() dto: SeedClanWarehouseDto) {
     return await this.farmWarehouseService.seedClanWarehouse(dto);

--- a/src/modules/clan-warehouse/clan-warehouse.controller.ts
+++ b/src/modules/clan-warehouse/clan-warehouse.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Query, BadRequestException, Param} from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, BadRequestException, Param, ParseUUIDPipe} from '@nestjs/common';
 import {ApiBearerAuth, ApiOperation, ApiTags, ApiQuery} from '@nestjs/swagger';
 import { CLanWarehouseService } from './clan-warehouse.service';
 import { BuyPlantDto, SeedClanWarehouseDto } from './dto/clan-warehouse.dto';
@@ -6,24 +6,25 @@ import { UserEntity } from '@modules/user/entity/user.entity';
 import { USER_TOKEN } from '@constant';
 import { ClsService } from 'nestjs-cls';
 import { RequireAdmin, RequireClanRoles } from '@libs/decorator';
+import { UUID } from 'crypto';
 
 @ApiBearerAuth()
 @ApiTags('Clan Warehouse')
-@Controller('Clan-Warehouses')
+@Controller('clans/:clan_id/Clan-Warehouses')
 export class ClanWarehouseController {
   constructor(
     private readonly farmWarehouseService: CLanWarehouseService,
     private readonly cls: ClsService,
   ) {}
 
-  @Get(':clan_id')
+  @Get()
   @ApiOperation({ summary: 'Get all item in warehouse for a clan' })
-  async getAllItemsInWarehouse(@Param('clan_id') clanId: string) {
+  async getAllItemsInWarehouse(@Param('clan_id', ParseUUIDPipe) clanId: string) {
     return this.farmWarehouseService.getAllItemsInWarehouse(clanId);
   }
 
   @Post('buy-items-clan')
-  @RequireClanRoles('LEADER')
+  @RequireClanRoles('LEADER', 'VICE_LEADER')
   @ApiOperation({ summary: 'Buy plant for a clan farm' })
   async buyItemsForClan(@Body() dto: BuyPlantDto) {
     const user = this.cls.get<UserEntity>(USER_TOKEN);
@@ -33,7 +34,8 @@ export class ClanWarehouseController {
   @Post('seed-plant-to-warehouse')
   @RequireAdmin()
   @ApiOperation({ summary: 'Add item in warehouse for a clan' })
-  async seedWarehouse(@Body() dto: SeedClanWarehouseDto) {
-    return await this.farmWarehouseService.seedClanWarehouse(dto);
+  async seedWarehouse(@Param('clan_id', ParseUUIDPipe) clanId: string,
+  @Body() dto: SeedClanWarehouseDto) {
+    return await this.farmWarehouseService.seedClanWarehouse(clanId, dto);
   }
 }

--- a/src/modules/clan-warehouse/clan-warehouse.service.ts
+++ b/src/modules/clan-warehouse/clan-warehouse.service.ts
@@ -33,14 +33,13 @@ export class CLanWarehouseService {
       throw new BadRequestException('Clan ID not found');
     }
 
-    const items = await this.warehouseRepo.find({
-      where: {
-        clan_id: clanId,
-        quantity: MoreThan(0),
-      },
-      relations: ['plant'],
-      order: { created_at: 'DESC' },
-    });
+    const items = await this.warehouseRepo
+    .createQueryBuilder('w')
+    .leftJoinAndSelect('w.plant', 'plant')
+    .where('w.clan_id = :clanId', { clanId })
+    .andWhere('w.quantity > 0')
+    .orderBy('plant.harvest_point', 'DESC')
+    .getMany();
 
     return {
       clanId,

--- a/src/modules/clan-warehouse/clan-warehouse.service.ts
+++ b/src/modules/clan-warehouse/clan-warehouse.service.ts
@@ -53,9 +53,9 @@ export class CLanWarehouseService {
     if (dto.quantity <= 0)
       throw new BadRequestException('Quantity must be greater than 0');
 
-    if (!user.clan_id || user.clan_role !== ClanRole.LEADER)
+    if (!user.clan_id || (user.clan_role !== ClanRole.LEADER && user.clan_role !== ClanRole.VICE_LEADER))
       throw new BadRequestException(
-        'Only clan leader can buy plants for clan farm',
+        'Only clan leader/vice leader can buy plants for clan farm',
       );
 
     const plant = await this.plantRepo.findOne({ where: { id: dto.itemId } });

--- a/src/modules/clan-warehouse/dto/clan-warehouse.dto.ts
+++ b/src/modules/clan-warehouse/dto/clan-warehouse.dto.ts
@@ -6,13 +6,6 @@ import { IsInt, Min, IsUUID, IsOptional, IsEnum, Max, IsArray } from 'class-vali
 
 export class BuyPlantDto {
   @ApiProperty({
-    example: '0b071122-8ac2-4886-a8bd-64e1694f3ba7',
-    description: 'Clan ID',
-  })
-  @IsUUID()
-  clanId: string;
-
-  @ApiProperty({
     example: '1c23a3d4-abc1-4d7a-b123-1a2b3c4d5e6f',
     description: 'Item Farm ID (UUID)',
   })
@@ -54,13 +47,6 @@ export class HarvestPlantStatusDto {
 }
 
 export class SeedClanWarehouseDto {
-  @ApiProperty({
-    description: 'ID của clan cần seed kho',
-    example: '6f185442-7fe2-4dcf-b3ba-59e873225ec0',
-  })
-  @IsUUID()
-  clanId: string;
-
   @ApiPropertyOptional({
     description: 'Số lượng mặc định cho mỗi item, nếu không truyền sẽ lấy 5',
     example: 5,

--- a/src/modules/clan/clan-member.controller.ts
+++ b/src/modules/clan/clan-member.controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@nestjs/swagger';
 import { ClsService } from 'nestjs-cls';
 import { ClanMemberService } from './clan-member.service';
-import { RemoveMembersDto } from './dto/clan.dto';
+import { AssignViceLeadersDto, RemoveMembersDto } from './dto/clan.dto';
 
 @ApiBearerAuth()
 @Controller('clans/:clan_id/members')
@@ -41,24 +41,24 @@ export class ClanMemberController {
     );
   }
 
-  @Patch(':target_user_id/assign-vice-leader')
+  @Patch('/assign-vice-leader')
   @RequireClanRoles('LEADER')
   @ApiOperation({ summary: 'Assign vice leader role to a clan member' })
   async assignViceLeader(
     @Param('clan_id', ParseUUIDPipe) clanId: string,
-    @Param('target_user_id', ParseUUIDPipe) targetUserId: string,
+    @Body() targetUserIds: AssignViceLeadersDto,
   ) {
-    return this.clanMemberService.assignViceLeader(clanId, targetUserId);
+    return this.clanMemberService.assignViceLeaders(clanId, targetUserIds.targetUserIds);
   }
 
-  @Patch(':target_user_id/remove-vice-leader')
+  @Patch('/remove-vice-leader')
   @RequireClanRoles('LEADER')
-  @ApiOperation({ summary: 'Remove vice leader role (demote to member)' })
+  @ApiOperation({ summary: 'Remove vice leaders role (demote to member)' })
   async removeViceLeader(
     @Param('clan_id', ParseUUIDPipe) clanId: string,
-    @Param('target_user_id', ParseUUIDPipe) targetUserId: string,
+    @Body() targetUserIds: AssignViceLeadersDto,
   ) {
-    return this.clanMemberService.removeViceLeader(clanId, targetUserId);
+    return this.clanMemberService.removeViceLeaders(clanId, targetUserIds.targetUserIds);
   }
 
   @Delete()

--- a/src/modules/clan/clan.service.ts
+++ b/src/modules/clan/clan.service.ts
@@ -210,28 +210,36 @@ export class ClanService extends BaseService<ClanEntity> {
     });
 
     let currentRank = 1;
+
     const usersWithRank = usersSortedByScore.map((u) => {
       const score = u.scores?.[0]?.total_score ?? 0;
       const weekly_score = u.scores?.[0]?.weekly_score ?? 0;
-      const rank = score > 0 ? currentRank++ : 0;
+
       return {
         ...plainToInstance(UserPublicDto, u),
         total_score: score,
         weekly_score,
-        rank,
+        rank: currentRank++,
       };
     });
 
-    const leaders = usersWithRank.filter(
-      (u) =>
-        u.clan_role === ClanRole.LEADER || u.clan_role === ClanRole.VICE_LEADER,
-    );
-    const members = usersWithRank.filter(
-      (u) =>
-        u.clan_role !== ClanRole.LEADER && u.clan_role !== ClanRole.VICE_LEADER,
-    );
+    const leaders = usersWithRank
+      .filter((u) => u.clan_role === ClanRole.LEADER)
+      .sort((a, b) => a.rank - b.rank);
 
-    const finalList = [...leaders, ...members];
+    const viceLeaders = usersWithRank
+      .filter((u) => u.clan_role === ClanRole.VICE_LEADER)
+      .sort((a, b) => a.rank - b.rank);
+
+    const members = usersWithRank
+      .filter(
+        (u) =>
+          u.clan_role !== ClanRole.LEADER &&
+          u.clan_role !== ClanRole.VICE_LEADER,
+      )
+      .sort((a, b) => a.rank - b.rank);
+
+    const finalList = [...leaders, ...viceLeaders, ...members];
 
     const start = (page - 1) * limit;
     const end = start + limit;

--- a/src/modules/clan/clan.service.ts
+++ b/src/modules/clan/clan.service.ts
@@ -165,8 +165,9 @@ export class ClanService extends BaseService<ClanEntity> {
       .getMany();
 
     const leader = users.find((u) => u.clan_role === ClanRole.LEADER) || null;
-    const viceLeader =
-      users.find((u) => u.clan_role === ClanRole.VICE_LEADER) || null;
+    const viceLeaders = users.filter(
+      (u) => u.clan_role === ClanRole.VICE_LEADER,
+    );
 
     // clanWithCount['leader'] = leader;
     // clanWithCount['vice_leader'] = viceLeader;
@@ -177,11 +178,11 @@ export class ClanService extends BaseService<ClanEntity> {
       weekly_score: leader?.scores?.[0]?.weekly_score ?? 0,
     };
 
-    clanWithCount['vice_leader'] = {
-      ...plainToInstance(UserInformationDto, viceLeader),
-      total_score: viceLeader?.scores?.[0]?.total_score ?? 0,
-      weekly_score: viceLeader?.scores?.[0]?.weekly_score ?? 0,
-    };
+    clanWithCount['vice_leaders'] = viceLeaders.map((v) => ({
+      ...plainToInstance(UserInformationDto, v),
+      total_score: v?.scores?.[0]?.total_score ?? 0,
+      weekly_score: v?.scores?.[0]?.weekly_score ?? 0,
+    }));
 
     return plainToInstance(ClanInfoResponseDto, clanWithCount);
   }

--- a/src/modules/clan/clan.service.ts
+++ b/src/modules/clan/clan.service.ts
@@ -398,10 +398,7 @@ export class ClanService extends BaseService<ClanEntity> {
         clan_id: clanId,
         total_score: 0,
         weekly_score: 0,
-        harvest_count: 100,
         harvest_count_use: 0,
-        harvest_interrupt_count: 100,
-        harvest_interrupt_count_use: 0,
         created_at: new Date(),
       });
       await this.userClantStatRepo.save(stat);

--- a/src/modules/clan/dto/clan.dto.ts
+++ b/src/modules/clan/dto/clan.dto.ts
@@ -105,3 +105,8 @@ export class SetUserClanRoleDto {
   @IsEnum(ClanRole)
   role: ClanRole;
 }
+
+export class AssignViceLeadersDto {
+  @IsUUID('all', { each: true })
+  targetUserIds: string[];
+}

--- a/src/modules/colyseus/rooms/base-game.room.ts
+++ b/src/modules/colyseus/rooms/base-game.room.ts
@@ -857,11 +857,12 @@ export class BaseGameRoom extends Room<RoomState> {
           });
           return;
         }
+        const ALLOWED_ROLES = [ClanRole.LEADER, ClanRole.VICE_LEADER];
         if (
           !player ||
           !user ||
           !user.clan_id ||
-          user.clan_role !== ClanRole.LEADER
+          !ALLOWED_ROLES.includes(user.clan_role)
         ) {
           client.send(MessageTypes.ON_BUY_CLAN_ITEM_FAILED, {
             message: !player
@@ -870,7 +871,7 @@ export class BaseGameRoom extends Room<RoomState> {
                 ? 'Không tìm thấy thông tin người dùng'
                 : !user.clan_id
                   ? 'Người dùng chưa thuộc clan nào'
-                  : 'Chỉ leader mới có thể mua item cho clan',
+                  : 'Chỉ Giám Đốc văn phòng/ Phó Giám Đốc mới có thể mua vật phẩm cho văn phòng',
           });
           return;
         }
@@ -879,7 +880,6 @@ export class BaseGameRoom extends Room<RoomState> {
           const result = await this.cLanWarehouseService.buyItemsForClanFarm(
             user,
             {
-              clanId: user.clan_id,
               itemId: payload.itemId,
               quantity: payload.quantity,
               type: InventoryClanType.PLANT,

--- a/src/modules/colyseus/rooms/farm.room.ts
+++ b/src/modules/colyseus/rooms/farm.room.ts
@@ -332,18 +332,18 @@ export class FarmRoom extends BaseGameRoom {
           return;
         }
 
-        const userStat = await this.farmSlotsService.getUserHarvestStat(
-          Player.user_id,
-          Player.clan_id,
-        );
-        const remaining = userStat.max - userStat.used;
-        if (remaining <= 0) {
-          client.send(MessageTypes.ON_HARVEST_DENIED, {
-            sessionId: client.sessionId,
-            message: 'Bạn đã hết lượt thu hoạch!',
-          });
-          return;
-        }
+        // const userStat = await this.farmSlotsService.getUserHarvestStat(
+        //   Player.user_id,
+        //   Player.clan_id,
+        // );
+        // const remaining = userStat.max - userStat.used;
+        // if (remaining <= 0) {
+        //   client.send(MessageTypes.ON_HARVEST_DENIED, {
+        //     sessionId: client.sessionId,
+        //     message: 'Bạn đã hết lượt thu hoạch!',
+        //   });
+        //   return;
+        // }
 
         if (!slot.currentPlant.can_harvest) {
           client.send(MessageTypes.ON_HARVEST_DENIED, {
@@ -446,12 +446,12 @@ export class FarmRoom extends BaseGameRoom {
           return;
         }
 
-        const result = await this.farmSlotsService.incrementHarvestInterrupted(
-          interrupter.user_id,
-          interrupter.clan_id,
-          targetPlayer.user_id,
-          targetPlayer.clan_id,
-        );
+        // const result = await this.farmSlotsService.incrementHarvestInterrupted(
+        //   interrupter.user_id,
+        //   interrupter.clan_id,
+        //   targetPlayer.user_id,
+        //   targetPlayer.clan_id,
+        // );
 
         const plantInfo = await this.farmSlotsService.decreaseHarvestCount(
           slot.id,
@@ -487,7 +487,7 @@ export class FarmRoom extends BaseGameRoom {
           slotId: slot.id,
           interruptedPlayer: targetPlayer.id,
           interruptedPlayerName: targetPlayer.display_name || 'Ẩn Danh',
-          selfHarvestInterrupt: result.interrupter,
+          //selfHarvestInterrupt: result.interrupter,
         });
 
         const targetClient = this.getClientBySessionId(targetPlayer.id);
@@ -497,7 +497,7 @@ export class FarmRoom extends BaseGameRoom {
             slotId: slot.id,
             interruptedBy: fromPlayerId,
             interruptedByName: interrupter?.display_name || 'Ẩn Danh',
-            selfHarvest: result.target,
+            //selfHarvest: result.target,
             plantHarvest: plantInfo,
           });
         }

--- a/src/modules/colyseus/rooms/farm.room.ts
+++ b/src/modules/colyseus/rooms/farm.room.ts
@@ -137,7 +137,6 @@ export class FarmRoom extends BaseGameRoom {
         newSlotState.harvestEndTime = slotState.harvestEndTime;
         newSlotState.currentPlant = newPlant;
         newSlotState.harvest_count = slotState.harvest_count;
-        newSlotState.harvest_count_max = slotState.harvest_count_max;
         this.state.farmSlotState.set(slotId, newSlotState);
         this.schedulePlant(slotId, newPlant);
       } catch (err: any) {
@@ -184,7 +183,7 @@ export class FarmRoom extends BaseGameRoom {
             slotBefore.currentPlant.created_at,
             slotBefore.currentPlant.grow_time,
             slotBefore.currentPlant.harvest_count,
-            slotBefore.currentPlant.harvest_count_max,
+            this.getFarmConfig(),
           );
 
           if (plantStage === PlantState.HARVESTABLE || canHarvest) {
@@ -267,7 +266,7 @@ export class FarmRoom extends BaseGameRoom {
             slotBefore.currentPlant.created_at,
             slotBefore.currentPlant.grow_time,
             slotBefore.currentPlant.harvest_count,
-            slotBefore.currentPlant.harvest_count_max,
+            this.getFarmConfig(),
           );
           if (canHarvest) {
             return;
@@ -482,10 +481,8 @@ export class FarmRoom extends BaseGameRoom {
 
         if (!slotState.currentPlant) return;
         newSlotState.harvest_count += 1;
-        const maxHarvest =
-          slotState.harvest_count_max ?? farmConfig.PLANT.MAX_HARVEST;
 
-        if (newSlotState.harvest_count >= maxHarvest) {
+        if (farmConfig.PLANT.ENABLE_LIMIT && newSlotState.harvest_count >= farmConfig.PLANT.MAX_HARVEST) {
           this.harvestTimers.delete(slot.id);
           this.resetPlant(slot.id);
           this.broadcast(MessageTypes.ON_PLANT_DEATH, {
@@ -544,7 +541,7 @@ export class FarmRoom extends BaseGameRoom {
                 createdAt,
                 growTime,
                 slot.harvest_count,
-                slot.harvest_count_max,
+                this.getFarmConfig(),
               );
             } else {
               slot.currentPlant.grow_time_remain = 0;
@@ -635,7 +632,7 @@ export class FarmRoom extends BaseGameRoom {
             createdAt,
             growTime,
             slot.harvest_count,
-            slot.harvest_count_max,
+            this.getFarmConfig(),
           );
         } else {
           slot.currentPlant.grow_time_remain = 0;
@@ -694,10 +691,10 @@ export class FarmRoom extends BaseGameRoom {
       p.created_at,
       p.grow_time,
       p.harvest_count,
-      p.harvest_count_max,
+      this.getFarmConfig(),
     );
-    schema.need_water = PlantCareUtils.checkNeedWater(p) ?? false;
-    schema.has_bug = PlantCareUtils.checkHasBug(p) ?? false;
+    schema.need_water = PlantCareUtils.checkNeedWater(p, this.getFarmConfig()) ?? false;
+    schema.has_bug = PlantCareUtils.checkHasBug(p, this.getFarmConfig()) ?? false;
     schema.harvest_at = p.harvest_at ? p.harvest_at.toISOString() : null;
     return schema;
   }
@@ -853,7 +850,6 @@ export class FarmRoom extends BaseGameRoom {
     newSlotState.id = slotState.id;
     newSlotState.slot_index = slotState.slot_index;
     newSlotState.harvest_count = slotState.harvest_count;
-    newSlotState.harvest_count_max = slotState.harvest_count_max;
     newSlotState.harvestingBy = slotState.harvestingBy;
     newSlotState.harvestEndTime = slotState.harvestEndTime;
 

--- a/src/modules/colyseus/rooms/farm.room.ts
+++ b/src/modules/colyseus/rooms/farm.room.ts
@@ -745,8 +745,8 @@ export class FarmRoom extends BaseGameRoom {
         clanMultiplier: result.clanMultiplier,
         totalScore: result.totalScore,
         bonusPercent: result.bonusPercent,
-        remainingHarvest: result.remaining,
-        maxHarvest: result.max,
+        // remainingHarvest: result.remaining,
+        // maxHarvest: result.max,
       });
     } catch (err) {
       this.logger.error(`[finishHarvest] DB update failed: ${err.message}`);
@@ -755,8 +755,8 @@ export class FarmRoom extends BaseGameRoom {
         client.send(MessageTypes.ON_HARVEST_DENIED, {
           message: err.response?.message || 'Cây chưa sẵn sàng thu hoạch!',
           slotId,
-          remaining: err.response?.remaining ?? null,
-          max: err.response?.max ?? null,
+          // remaining: err.response?.remaining ?? null,
+          // max: err.response?.max ?? null,
         });
       }
     }

--- a/src/modules/colyseus/rooms/game.room.ts
+++ b/src/modules/colyseus/rooms/game.room.ts
@@ -39,7 +39,7 @@ export class GameRoom extends BaseGameRoom {
 
       if (this.mathProblemData.id == id && this.mathProblemData.answer == answer.toString()) {
         if (client.userData) {
-          client.userData.gold += 1;
+          client.userData.gold += 100;
           response.correct = true;
           response.userGold = client.userData.gold;
           this.userRepository.update(client.userData.id, { gold: client.userData.gold });

--- a/src/modules/farm-slots/farm-slots.module.ts
+++ b/src/modules/farm-slots/farm-slots.module.ts
@@ -13,9 +13,12 @@ import { UserClanStatEntity } from '@modules/user-clan-stat/entity/user-clan-sta
 import { UserClanStatService } from '@modules/user-clan-stat/user-clan-stat.service';
 import { ClanActivityModule } from '@modules/clan-activity/clan-activity.module';
 import { ClanFundModule } from '@modules/clan-fund/clan-fund.module';
+import { GameConfigStore } from '@modules/admin/game-config/game-config.store';
+import { GameConfigModule } from '@modules/admin/game-config/game-config.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([FarmSlotEntity, SlotsPlantEntity, ClanWarehouseEntity, PlantEntity, UserEntity, FarmEntity, UserClanStatEntity]), ClanWarehouseModule, ClanActivityModule, ClanFundModule],
+  imports: [TypeOrmModule.forFeature([FarmSlotEntity, SlotsPlantEntity, ClanWarehouseEntity, PlantEntity, UserEntity, FarmEntity, UserClanStatEntity]), ClanWarehouseModule, ClanActivityModule, ClanFundModule,
+  GameConfigModule],
   providers: [FarmSlotService, UserClanStatService],
   controllers: [FarmSlotsController],
 })

--- a/src/modules/farm-slots/farm-slots.service.ts
+++ b/src/modules/farm-slots/farm-slots.service.ts
@@ -25,6 +25,8 @@ import { UserClanStatEntity as UserClanStatEntity } from '@modules/user-clan-sta
 import { UserClanStatService } from '@modules/user-clan-stat/user-clan-stat.service';
 import { ClanActivityService } from '@modules/clan-activity/clan-activity.service';
 import { ClanFundService } from '@modules/clan-fund/clan-fund.service';
+import { GameConfigStore } from '@modules/admin/game-config/game-config.store';
+import { GAME_CONFIG_KEYS } from '@constant/game-config.keys';
 
 @Injectable()
 export class FarmSlotService {
@@ -47,7 +49,15 @@ export class FarmSlotService {
     private readonly userClanStatService: UserClanStatService,
     private readonly clanActivityService: ClanActivityService,
     private readonly clanFundService: ClanFundService,
+    private readonly configStore: GameConfigStore,
   ) {}
+
+  private getFarmConfig(): typeof FARM_CONFIG {
+    return (
+      this.configStore.get<typeof FARM_CONFIG>(GAME_CONFIG_KEYS.FARM) ??
+      FARM_CONFIG
+    );
+  }
 
   async getFarmWithSlotsByClan(clan_id: string): Promise<FarmWithSlotsDto> {
     if (!clan_id) throw new NotFoundException('clan_id is required');
@@ -185,14 +195,17 @@ export class FarmSlotService {
     slot: FarmSlotEntity,
     plant: SlotsPlantEntity,
   ): Promise<boolean> {
+
+    const farmConfig = this.getFarmConfig();
+
     const now = new Date();
     const deathAt = new Date(
-      plant.created_at.getTime() + FARM_CONFIG.PLANT.DEATH_MS,
+      plant.created_at.getTime() + farmConfig.PLANT.DEATH_MS,
     );
 
     if (
-      now >= deathAt &&
-      (plant.harvest_count ?? 0) < FARM_CONFIG.PLANT.MAX_HARVEST
+      now >= deathAt && farmConfig.PLANT.ENABLE_LIMIT &&
+      (plant.harvest_count ?? 0) < farmConfig.PLANT.MAX_HARVEST
     ) {
       slot.current_slot_plant_id = null;
       await this.farmSlotRepo.save(slot);
@@ -371,10 +384,16 @@ export class FarmSlotService {
         ...(clanId ? { clan_id: clanId } : {}),
       },
     });
-
+    const farmConfig = this.getFarmConfig();
     const used = stat?.harvest_count_use ?? 0;
-    const max = stat?.harvest_count ?? FARM_CONFIG.HARVEST.MAX_HARVEST;
-    const remaining = Math.max(max - used, 0);
+    const max = farmConfig.HARVEST.ENABLE_LIMIT
+      ? farmConfig.HARVEST.MAX_HARVEST
+      : FARM_CONFIG.HARVEST.UNLIMITED;
+
+    const remaining =
+      max === farmConfig.HARVEST.UNLIMITED
+        ? FARM_CONFIG.HARVEST.UNLIMITED
+        : Math.max(max - used, 0);
 
     return { used, max, remaining };
   }
@@ -386,18 +405,23 @@ export class FarmSlotService {
     });
     if (!user?.clan) throw new BadRequestException('Người chơi không có clan');
 
-    // const { score } = await this.userClanStatService.getOrCreateUserClanStat(
-    //   userId,
-    //   user.clan.id,
-    // );
-    // const used = score?.harvest_count_use ?? 0;
-    // const max = score?.harvest_count ?? 0;
-    // if (used >= max)
-    //   throw new BadRequestException({
-    //     message: 'Đã sử dụng hết lượt thu hoạch',
-    //     remaining: 0,
-    //     max,
-    //   });
+    const { score } = await this.userClanStatService.getOrCreateUserClanStat(
+      userId,
+      user.clan.id,
+    );
+    const used = score?.harvest_count_use ?? 0;
+    const farmConfig = this.getFarmConfig();
+    const max = farmConfig.HARVEST.ENABLE_LIMIT
+      ? farmConfig.HARVEST.MAX_HARVEST
+      : farmConfig.HARVEST.UNLIMITED;
+    if (farmConfig.HARVEST.ENABLE_LIMIT && used >= max) {
+      throw new BadRequestException({
+        message: 'Đã sử dụng hết lượt thu hoạch',
+        remaining: 0,
+        max,
+      });
+    } 
+
     const slot = await this.farmSlotRepo.findOne({
       where: { id: farmSlotId },
       relations: ['currentSlotPlant', 'currentSlotPlant.plant', 'farm'],
@@ -415,8 +439,8 @@ export class FarmSlotService {
     if (!canHarvest)
       throw new BadRequestException('Plant not ready for harvest');
 
-    // slotPlant.harvest_count ??= 0;
-    // slotPlant.harvest_count += 1;
+    slotPlant.harvest_count ??= 0;
+    slotPlant.harvest_count += 1;
     slotPlant.harvest_at = new Date();
     slotPlant.last_harvested_by = user.id;
     const isIntruder = slot.farm.clan_id !== user.clan.id;
@@ -443,18 +467,15 @@ export class FarmSlotService {
     );
     const waterRatio = Math.min(slotPlant.total_water_count / totalWater, 1);
     const bugRatio = Math.min(slotPlant.total_bug_caught / totalBug, 1);
-    const careRatio = FARM_CONFIG.HARVEST.FORMULA.WATER_WEIGHT * waterRatio + FARM_CONFIG.HARVEST.FORMULA.BUG_WEIGHT * bugRatio;
+    const careRatio = farmConfig.HARVEST.FORMULA.WATER_WEIGHT * waterRatio + farmConfig.HARVEST.FORMULA.BUG_WEIGHT * bugRatio;
     const baseScore = slotPlant.plant?.harvest_point ?? 1;
-    const multiplierRatio = FARM_CONFIG.HARVEST.FORMULA.MIN_MULTIPLIER + FARM_CONFIG.HARVEST.FORMULA.CARE_FACTOR * careRatio;
-    const clanMultiplier = isIntruder ? FARM_CONFIG.HARVEST.FORMULA.OTHER_CLAN : FARM_CONFIG.HARVEST.FORMULA.MY_CLAN;
+    const multiplierRatio = farmConfig.HARVEST.FORMULA.MIN_MULTIPLIER + farmConfig.HARVEST.FORMULA.CARE_FACTOR * careRatio;
+    const clanMultiplier = isIntruder ? farmConfig.HARVEST.FORMULA.OTHER_CLAN: farmConfig.HARVEST.FORMULA.MY_CLAN;
     const careBonus = Math.round((multiplierRatio - 1) * 100);
     const finalScore = Math.floor(baseScore * multiplierRatio * clanMultiplier);
     const bonusPercent = Math.round(((finalScore - baseScore) / baseScore) * 100);
 
-    await this.clanFundService.addToFund(user.clan.id, user, {
-      type: ClanFundType.GOLD ,
-      amount: finalScore,
-    });
+    await this.clanFundService.addToFund(user.clan.id, user, { type: ClanFundType.GOLD, amount: finalScore});
 
     if (isIntruder) {
       await this.clanActivityService.logActivity({
@@ -464,7 +485,7 @@ export class FarmSlotService {
         itemName: slotPlant.plant?.name ?? 'vật phẩm',
         quantity: 1,
         amount: finalScore,
-        officeName: user.clan.farm?.name ?? (user.clan.name + " Farm"),
+        officeName: user.clan.farm?.name ?? user.clan.name + ' Farm',
       });
 
       await this.clanActivityService.logActivity({
@@ -484,26 +505,27 @@ export class FarmSlotService {
         itemName: slotPlant.plant?.name ?? 'vật phẩm',
         quantity: 1,
         amount: finalScore,
-        officeName: slot.farm.name ?? (user.clan.name + " Farm"),
+        officeName: slot.farm.name ?? user.clan.name + ' Farm',
       });
     }
 
-    await this.userClanStatService.addScore(user.id, user.clan.id, finalScore);
+    await this.userClanStatService.addScore(user.id, user.clan.id, finalScore, farmConfig.HARVEST.ENABLE_LIMIT );
     slot.current_slot_plant_id = null;
     await this.farmSlotRepo.save(slot);
     await this.slotPlantRepo.softRemove(slotPlant);
+   
     return {
       success: true,
       message: isIntruder
         ? 'Harvest (intruder) successful'
         : 'Harvest successful',
-      //remaining: Math.max(max - (used + 1), 0),
+      remaining: farmConfig.HARVEST.ENABLE_LIMIT ? Math.max(max - (used + 1), 0): farmConfig.HARVEST.UNLIMITED,
       baseScore: baseScore,
       careBonus,
       clanMultiplier,
       totalScore: finalScore,
       bonusPercent: bonusPercent,
-      //max,
+      max: farmConfig.HARVEST.ENABLE_LIMIT ? farmConfig.HARVEST.MAX_HARVEST: farmConfig.HARVEST.UNLIMITED,
     };
   }
 
@@ -524,23 +546,22 @@ export class FarmSlotService {
       throw new NotFoundException('Không tìm thấy người phá');
     }
 
+    const farmConfig = this.getFarmConfig();
     interrupterStat.harvest_interrupt_count_use ??= 0;
-    interrupterStat.harvest_interrupt_count ??=
-      FARM_CONFIG.HARVEST.MAX_INTERRUPT;
 
     if (
+      farmConfig.HARVEST.ENABLE_LIMIT &&
       interrupterStat.harvest_interrupt_count_use >=
-      interrupterStat.harvest_interrupt_count
+      farmConfig.HARVEST.MAX_INTERRUPT
     ) {
       throw new BadRequestException('Người phá đã hết lượt phá thu hoạch!');
     }
 
-    interrupterStat.harvest_interrupt_count_use += 1;
-    await this.userClanStatRepo.save(interrupterStat);
+    if (farmConfig.HARVEST.ENABLE_LIMIT ) {
+      interrupterStat.harvest_interrupt_count_use += 1;
+      await this.userClanStatRepo.save(interrupterStat);
+    }
 
-    const interrupterRemaining =
-      interrupterStat.harvest_interrupt_count -
-      interrupterStat.harvest_interrupt_count_use;
 
     const targetStat = await this.userClanStatRepo.findOne({
       where: {
@@ -554,30 +575,30 @@ export class FarmSlotService {
     }
 
     targetStat.harvest_count_use ??= 0;
-    targetStat.harvest_count ??= FARM_CONFIG.HARVEST.MAX_HARVEST;
-
-    if (targetStat.harvest_count_use >= targetStat.harvest_count) {
+    if (
+      farmConfig.HARVEST.ENABLE_LIMIT &&
+      targetStat.harvest_count_use >= farmConfig.HARVEST.MAX_HARVEST
+    ) {
       throw new BadRequestException(
         'Người thu hoạch bị phá đã hết lượt thu hoạch!',
       );
     }
 
-    targetStat.harvest_count_use += 1;
-    await this.userClanStatRepo.save(targetStat);
-
-    const targetRemaining =
-      targetStat.harvest_count - targetStat.harvest_count_use;
+    if (farmConfig.HARVEST.ENABLE_LIMIT) {
+      targetStat.harvest_count_use += 1;
+      await this.userClanStatRepo.save(targetStat);
+    }
 
     return {
       interrupter: {
         used: interrupterStat.harvest_interrupt_count_use,
-        max: interrupterStat.harvest_interrupt_count,
-        remaining: interrupterRemaining,
+        max: farmConfig.HARVEST.ENABLE_LIMIT ? farmConfig.HARVEST.MAX_INTERRUPT : farmConfig.HARVEST.UNLIMITED,
+        remaining: farmConfig.HARVEST.ENABLE_LIMIT ? farmConfig.HARVEST.MAX_INTERRUPT - interrupterStat.harvest_interrupt_count_use: farmConfig.HARVEST.UNLIMITED,
       },
       target: {
         used: targetStat.harvest_count_use,
-        max: targetStat.harvest_count,
-        remaining: targetRemaining,
+        max: farmConfig.HARVEST.ENABLE_LIMIT ? farmConfig.HARVEST.MAX_HARVEST: farmConfig.HARVEST.UNLIMITED,
+        remaining: farmConfig.HARVEST.ENABLE_LIMIT ? farmConfig.HARVEST.MAX_HARVEST - targetStat.harvest_count_use: farmConfig.HARVEST.UNLIMITED,
       },
     };
   }
@@ -593,12 +614,20 @@ export class FarmSlotService {
     slotPlant.harvest_count ??= 0;
     slotPlant.harvest_count += 1;
 
-    const maxHarvest =
-      slotPlant.harvest_count_max ?? FARM_CONFIG.PLANT.MAX_HARVEST;
+    const farmConfig = this.getFarmConfig();
+    const maxHarvest = farmConfig.PLANT.ENABLE_LIMIT
+      ? farmConfig.PLANT.MAX_HARVEST
+      : farmConfig.HARVEST.UNLIMITED;
 
-    const remaining = Math.max(maxHarvest - slotPlant.harvest_count, 0);
+    const remaining =
+      maxHarvest === farmConfig.PLANT.UNLIMITED
+        ? farmConfig.PLANT.UNLIMITED
+        : Math.max(maxHarvest - slotPlant.harvest_count, 0);
 
-    if (slotPlant.harvest_count >= maxHarvest) {
+    if (
+      maxHarvest !== farmConfig.PLANT.UNLIMITED &&
+      slotPlant.harvest_count >= maxHarvest
+    ) {
       slot.current_slot_plant_id = null;
       await this.farmSlotRepo.save(slot);
       await this.slotPlantRepo.softRemove(slotPlant);

--- a/src/modules/farm-slots/farm-slots.service.ts
+++ b/src/modules/farm-slots/farm-slots.service.ts
@@ -386,18 +386,18 @@ export class FarmSlotService {
     });
     if (!user?.clan) throw new BadRequestException('Người chơi không có clan');
 
-    const { score } = await this.userClanStatService.getOrCreateUserClanStat(
-      userId,
-      user.clan.id,
-    );
-    const used = score?.harvest_count_use ?? 0;
-    const max = score?.harvest_count ?? 0;
-    if (used >= max)
-      throw new BadRequestException({
-        message: 'Đã sử dụng hết lượt thu hoạch',
-        remaining: 0,
-        max,
-      });
+    // const { score } = await this.userClanStatService.getOrCreateUserClanStat(
+    //   userId,
+    //   user.clan.id,
+    // );
+    // const used = score?.harvest_count_use ?? 0;
+    // const max = score?.harvest_count ?? 0;
+    // if (used >= max)
+    //   throw new BadRequestException({
+    //     message: 'Đã sử dụng hết lượt thu hoạch',
+    //     remaining: 0,
+    //     max,
+    //   });
     const slot = await this.farmSlotRepo.findOne({
       where: { id: farmSlotId },
       relations: ['currentSlotPlant', 'currentSlotPlant.plant', 'farm'],
@@ -415,8 +415,8 @@ export class FarmSlotService {
     if (!canHarvest)
       throw new BadRequestException('Plant not ready for harvest');
 
-    slotPlant.harvest_count ??= 0;
-    slotPlant.harvest_count += 1;
+    // slotPlant.harvest_count ??= 0;
+    // slotPlant.harvest_count += 1;
     slotPlant.harvest_at = new Date();
     slotPlant.last_harvested_by = user.id;
     const isIntruder = slot.farm.clan_id !== user.clan.id;
@@ -497,13 +497,13 @@ export class FarmSlotService {
       message: isIntruder
         ? 'Harvest (intruder) successful'
         : 'Harvest successful',
-      remaining: Math.max(max - (used + 1), 0),
+      //remaining: Math.max(max - (used + 1), 0),
       baseScore: baseScore,
       careBonus,
       clanMultiplier,
       totalScore: finalScore,
       bonusPercent: bonusPercent,
-      max,
+      //max,
     };
   }
 

--- a/src/modules/game/game.module.ts
+++ b/src/modules/game/game.module.ts
@@ -11,6 +11,8 @@ import { InventoryModule } from '@modules/inventory/inventory.module';
 import { ItemModule } from '@modules/item/item.module';
 import { FoodModule } from '@modules/food/food.module';
 import { PlayerQuestModule } from '@modules/player-quest/player-quest.module';
+import { GameConfigStore } from '@modules/admin/game-config/game-config.store';
+import { GameConfigModule } from '@modules/admin/game-config/game-config.module';
 
 @Module({
   imports: [
@@ -19,7 +21,8 @@ import { PlayerQuestModule } from '@modules/player-quest/player-quest.module';
     InventoryModule,
     FoodModule,
     ItemModule,
-    PlayerQuestModule
+    PlayerQuestModule,
+    GameConfigModule
   ],
   controllers: [GameController],
   providers: [GameService],

--- a/src/modules/number-rarity/dto/number-rarity.dto.ts
+++ b/src/modules/number-rarity/dto/number-rarity.dto.ts
@@ -1,0 +1,54 @@
+import { IsValidRoomCode } from "@libs/decorator";
+import { ApiProperty, OmitType, PartialType } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsNumber, IsString } from "class-validator";
+
+export class CreateNumberRarityDto {
+  @ApiProperty({
+    description: 'Room code where the pet is located.',
+    example: 'sg',
+  })
+  @IsString()
+  @IsValidRoomCode()
+  room_code: string;
+
+  @ApiProperty({
+    description: 'Number of common pets to fill',
+    type: Number,
+    default: 6,
+  })
+  @IsNumber()
+  @Type(() => Number)
+  common_number: number;
+
+  @ApiProperty({
+    description: 'Number of rare pets to fill',
+    type: Number,
+    default: 3,
+  })
+  @IsNumber()
+  @Type(() => Number)
+  rare_number: number;
+
+  @ApiProperty({
+    description: 'Number of epic pets to fill',
+    type: Number,
+    default: 1,
+  })
+  @IsNumber()
+  @Type(() => Number)
+  epic_number: number;
+
+  @ApiProperty({
+    description: 'Number of legendary pets to fill',
+    type: Number,
+    default: 0,
+  })
+  @IsNumber()
+  @Type(() => Number)
+  legendary_number: number;
+}
+
+export class UpdateNumberRarityDto extends PartialType(
+  OmitType(CreateNumberRarityDto, ['room_code'] as const),
+) {}

--- a/src/modules/number-rarity/entity/number-rarity.entity.ts
+++ b/src/modules/number-rarity/entity/number-rarity.entity.ts
@@ -1,0 +1,45 @@
+import { IsValidRoomCode } from '@libs/decorator';
+import { ApiProperty } from '@nestjs/swagger';
+import { AuditEntity } from '@types';
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsString,
+} from 'class-validator';
+import { Column, Entity } from 'typeorm';
+
+@Entity('number_rarity')
+export class NumberRarityEntity extends AuditEntity {
+  @Column({ type: 'varchar', length: 255, unique: true })
+  @ApiProperty({
+    description: 'Room code where the pet is located.',
+    example: 'sg',
+  })
+  @IsString()
+  @IsValidRoomCode()
+  room_code: string;
+
+  @Column({ type: 'int', default: 6 })
+  @ApiProperty()
+  @IsInt()
+  @Type(() => Number)
+  common_number: number = 6;
+
+  @Column({ type: 'int', default: 3 })
+  @ApiProperty()
+  @IsInt()
+  @Type(() => Number)
+  rare_number: number = 3;
+
+  @Column({ type: 'int', default: 1 })
+  @ApiProperty()
+  @IsInt()
+  @Type(() => Number)
+  epic_number: number = 1;
+
+  @Column({ type: 'int', default: 0 })
+  @ApiProperty()
+  @IsInt()
+  @Type(() => Number)
+  legendary_number: number = 0;
+}

--- a/src/modules/number-rarity/number-rarity.controller.ts
+++ b/src/modules/number-rarity/number-rarity.controller.ts
@@ -6,8 +6,7 @@ import {
   Post,
   Put,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
-import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { NumberRarityService } from '@modules/number-rarity/number-rarity.service';
 
 @ApiBearerAuth()
@@ -19,16 +18,24 @@ export class NumberRarityController {
   ) {}
 
   @Get()
-  @ApiOperation({ summary: 'Get all number rarity configs' })
-  findAll(): Promise<NumberRarityEntity[]> {
+  @ApiOperation({ 
+    summary: 'Get all number rarity configs' 
+  })
+  findAll() {
     return this.service.findAll();
   }
 
   @Get(':roomCode')
-  @ApiOperation({ summary: 'Get number rarity by room code' })
+  @ApiParam({
+    name: 'roomCode',
+    example: 'sg',
+  })
+  @ApiOperation({ 
+    summary: 'Get number rarity by room code' 
+  })
   findByRoomCode(
     @Param('roomCode') roomCode: string,
-  ): Promise<NumberRarityEntity> {
+  ) {
     return this.service.findByRoomCode(roomCode);
   }
 }

--- a/src/modules/number-rarity/number-rarity.controller.ts
+++ b/src/modules/number-rarity/number-rarity.controller.ts
@@ -1,0 +1,34 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
+import { NumberRarityService } from '@modules/number-rarity/number-rarity.service';
+
+@ApiBearerAuth()
+@Controller('number-rarity')
+@ApiTags('Number Rarity')
+export class NumberRarityController {
+  constructor(
+    private readonly service: NumberRarityService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get all number rarity configs' })
+  findAll(): Promise<NumberRarityEntity[]> {
+    return this.service.findAll();
+  }
+
+  @Get(':roomCode')
+  @ApiOperation({ summary: 'Get number rarity by room code' })
+  findByRoomCode(
+    @Param('roomCode') roomCode: string,
+  ): Promise<NumberRarityEntity> {
+    return this.service.findByRoomCode(roomCode);
+  }
+}

--- a/src/modules/number-rarity/number-rarity.module.ts
+++ b/src/modules/number-rarity/number-rarity.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NumberRarityController } from './number-rarity.controller';
+import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
+import { NumberRarityService } from '@modules/number-rarity/number-rarity.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([NumberRarityEntity]),
+  ],
+  controllers: [NumberRarityController],
+  providers: [NumberRarityService],
+  exports: [NumberRarityService],
+})
+export class NumberRarityModule {}

--- a/src/modules/number-rarity/number-rarity.service.ts
+++ b/src/modules/number-rarity/number-rarity.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { CreateNumberRarityDto, UpdateNumberRarityDto } from '@modules/number-rarity/dto/number-rarity.dto';
+import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
+import { BaseService } from '@libs/base/base.service';
+
+@Injectable()
+export class NumberRarityService extends BaseService<NumberRarityEntity> {
+  constructor(
+    @InjectRepository(NumberRarityEntity)
+    private readonly numberRarityRepository: Repository<NumberRarityEntity>,
+    private manager: EntityManager,
+  ) {
+    super(numberRarityRepository, NumberRarityEntity.name);
+  }
+
+  async createNumberRarity(dto: CreateNumberRarityDto) {
+    const entity = this.numberRarityRepository.create(dto);
+    return this.numberRarityRepository.save(entity);
+  }
+
+  async findAll() {
+    return this.numberRarityRepository.find();
+  }
+
+  async findByRoomCode(roomCode: string) {
+    const entity = await this.numberRarityRepository.findOne({
+      where: { room_code: roomCode },
+    });
+
+    if (!entity) {
+      throw new NotFoundException(
+        `NumberRarity not found for room_code=${roomCode}`,
+      );
+    }
+
+    return entity;
+  }
+
+  async updateNumberRarity(roomCode: string, dto: UpdateNumberRarityDto) {
+    const entity = await this.findByRoomCode(roomCode);
+
+    Object.assign(entity, dto);
+    return this.numberRarityRepository.save(entity);
+  }
+}

--- a/src/modules/number-rarity/number-rarity.service.ts
+++ b/src/modules/number-rarity/number-rarity.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EntityManager, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { CreateNumberRarityDto, UpdateNumberRarityDto } from '@modules/number-rarity/dto/number-rarity.dto';
 import { NumberRarityEntity } from '@modules/number-rarity/entity/number-rarity.entity';
 import { BaseService } from '@libs/base/base.service';
@@ -10,7 +10,6 @@ export class NumberRarityService extends BaseService<NumberRarityEntity> {
   constructor(
     @InjectRepository(NumberRarityEntity)
     private readonly numberRarityRepository: Repository<NumberRarityEntity>,
-    private manager: EntityManager,
   ) {
     super(numberRarityRepository, NumberRarityEntity.name);
   }

--- a/src/modules/number-rarity/number-rarity.service.ts
+++ b/src/modules/number-rarity/number-rarity.service.ts
@@ -16,8 +16,8 @@ export class NumberRarityService extends BaseService<NumberRarityEntity> {
   }
 
   async createNumberRarity(dto: CreateNumberRarityDto) {
-    const entity = this.numberRarityRepository.create(dto);
-    return this.numberRarityRepository.save(entity);
+    const numberRarity = this.numberRarityRepository.create(dto);
+    return this.numberRarityRepository.save(numberRarity);
   }
 
   async findAll() {
@@ -25,23 +25,19 @@ export class NumberRarityService extends BaseService<NumberRarityEntity> {
   }
 
   async findByRoomCode(roomCode: string) {
-    const entity = await this.numberRarityRepository.findOne({
+    const numberRarity = await this.numberRarityRepository.findOne({
       where: { room_code: roomCode },
     });
 
-    if (!entity) {
-      throw new NotFoundException(
-        `NumberRarity not found for room_code=${roomCode}`,
-      );
-    }
+    if (!numberRarity) throw new NotFoundException(`NumberRarity not found for room_code=${roomCode}`);
 
-    return entity;
+    return numberRarity;
   }
 
   async updateNumberRarity(roomCode: string, dto: UpdateNumberRarityDto) {
-    const entity = await this.findByRoomCode(roomCode);
+    const numberRarity = await this.findByRoomCode(roomCode);
 
-    Object.assign(entity, dto);
-    return this.numberRarityRepository.save(entity);
+    Object.assign(numberRarity, dto);
+    return this.numberRarityRepository.save(numberRarity);
   }
 }

--- a/src/modules/pet-players/dto/pet-players.dto.ts
+++ b/src/modules/pet-players/dto/pet-players.dto.ts
@@ -326,4 +326,16 @@ export class GameConfigResponseDto {
       none: number;
     };
   };
+
+  farmLimit: {
+    plant: {
+      enabledLimit: boolean;
+      maxHarvest: number;
+    };
+    harvest: {
+      enabledLimit: boolean;
+      maxHarvest: number;
+      maxInterrupt: number;
+    };
+  };
 }

--- a/src/modules/pet-players/pet-players.module.ts
+++ b/src/modules/pet-players/pet-players.module.ts
@@ -10,6 +10,7 @@ import { PetPlayersController } from './pet-players.controller';
 import { PetPlayersService } from './pet-players.service';
 import { PetSkillsModule } from '@modules/pet-skills/pet-skills.module';
 import { PetSkillUsageEntity } from '@modules/pet-skill-usages/entity/pet-skill-usages.entity';
+import { NumberRarityModule } from '@modules/number-rarity/number-rarity.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { PetSkillUsageEntity } from '@modules/pet-skill-usages/entity/pet-skill-
     ]),
     ClsModule,
     PetSkillsModule,
+    NumberRarityModule,
     forwardRef(() => UserModule),
   ],
   providers: [PetPlayersService],

--- a/src/modules/pet-players/pet-players.service.ts
+++ b/src/modules/pet-players/pet-players.service.ts
@@ -151,9 +151,7 @@ export class PetPlayersService extends BaseService<PetPlayersEntity> {
     });
 
     if (!pets.length) {
-      throw new Error(
-        `No pet found with rarity=${rarity}`,
-      );
+      throw new Error(`No pet found with rarity=${rarity}`);
     }
 
     return this.randomItem(pets).type;
@@ -166,9 +164,7 @@ export class PetPlayersService extends BaseService<PetPlayersEntity> {
     });
 
     if (!pets.length) {
-      throw new Error(
-        `No pet found with rarity=${rarity} and type=${type}`,
-      );
+      throw new Error(`No pet found with rarity=${rarity} and type=${type}`);
     }
 
     return this.randomItem(pets).species;

--- a/src/modules/pet-players/pet-players.service.ts
+++ b/src/modules/pet-players/pet-players.service.ts
@@ -7,7 +7,7 @@ import {
   STAR_MULTIPLIER,
   UPGRADE_PET_RATES
 } from '@constant';
-import { AnimalRarity, SkillCode } from '@enum';
+import { AnimalRarity, PetType, SkillCode } from '@enum';
 import { BaseService } from '@libs/base/base.service';
 import { Logger } from '@libs/logger';
 import { getExpForNextLevel, getRarityUpgradeMultiplier, serializeDto } from '@libs/utils';
@@ -142,6 +142,83 @@ export class PetPlayersService extends BaseService<PetPlayersEntity> {
     }
 
     return await this.petPlayersRepository.save(petPlayers);
+  }
+
+  private async getRandomType(rarity: AnimalRarity): Promise<string> {
+    const pets = await this.petsRepository.find({
+      where: { rarity },
+      select: ['type'],
+    });
+
+    if (!pets.length) {
+      throw new Error(
+        `No pet found with rarity=${rarity}`,
+      );
+    }
+
+    return this.randomItem(pets).type;
+  }
+
+  private async getRandomSpecies(rarity: AnimalRarity, type: PetType): Promise<string> {
+    const pets = await this.petsRepository.find({
+      where: { rarity, type },
+      select: ['species'],
+    });
+
+    if (!pets.length) {
+      throw new Error(
+        `No pet found with rarity=${rarity} and type=${type}`,
+      );
+    }
+
+    return this.randomItem(pets).species;
+  }
+
+  async fillMissingPetsByRoom(room_code: string, common: number, rare: number, epic: number, legendary: number) {
+    const pets = await this.getAvailablePetPlayersWithRoom(room_code);
+
+    const countByRarity: Record<AnimalRarity, number> = {
+      [AnimalRarity.COMMON]: 0,
+      [AnimalRarity.RARE]: 0,
+      [AnimalRarity.EPIC]: 0,
+      [AnimalRarity.LEGENDARY]: 0,
+    };
+
+    for (const pet of pets) {
+      countByRarity[pet.current_rarity]++;
+    }
+
+    const targetRarity = {
+      [AnimalRarity.COMMON]: common,
+      [AnimalRarity.RARE]: rare,
+      [AnimalRarity.EPIC]: epic,
+      [AnimalRarity.LEGENDARY]: legendary,
+    };
+
+    for (const [rarity, target] of Object.entries(targetRarity)) {
+      const current = countByRarity[rarity as AnimalRarity];
+      const missing = target - current;
+
+      if (missing <= 0) continue;
+
+      for (let i = 0; i < missing; i++) {
+        const randomType = await this.getRandomType(rarity as AnimalRarity);
+        const randomSpecies = await this.getRandomSpecies(
+          rarity as AnimalRarity,
+          randomType as PetType,
+        );
+
+        await this.createPetPlayers(
+          {
+            room_code,
+            rarity: rarity as AnimalRarity,
+            type: randomType as PetType,
+            species: randomSpecies,
+          },
+          1,
+        );
+      }
+    }
   }
 
   async findPetPlayersWithPet(where: FindOptionsWhere<PetPlayersEntity>) {
@@ -848,5 +925,9 @@ export class PetPlayersService extends BaseService<PetPlayersEntity> {
 
   generateIndividualValue(): number {
     return Math.floor(Math.random() * 31) + 1;
+  }
+
+  randomItem<T>(arr: T[]): T {
+    return arr[Math.floor(Math.random() * arr.length)];
   }
 }

--- a/src/modules/pet-players/pet-players.service.ts
+++ b/src/modules/pet-players/pet-players.service.ts
@@ -144,7 +144,7 @@ export class PetPlayersService extends BaseService<PetPlayersEntity> {
     return await this.petPlayersRepository.save(petPlayers);
   }
 
-  private async getRandomType(rarity: AnimalRarity): Promise<string> {
+  private async getRandomType(rarity: AnimalRarity) {
     const pets = await this.petsRepository.find({
       where: { rarity },
       select: ['type'],
@@ -157,7 +157,7 @@ export class PetPlayersService extends BaseService<PetPlayersEntity> {
     return this.randomItem(pets).type;
   }
 
-  private async getRandomSpecies(rarity: AnimalRarity, type: PetType): Promise<string> {
+  private async getRandomSpecies(rarity: AnimalRarity, type: PetType) {
     const pets = await this.petsRepository.find({
       where: { rarity, type },
       select: ['species'],

--- a/src/modules/plant/plant-care.service.ts
+++ b/src/modules/plant/plant-care.service.ts
@@ -59,17 +59,17 @@ export class PlantCareUtils {
     return Math.max(0, Math.ceil((growEnd - now) / 1000));
   }
 
-  static checkCanHarvest(createdAt: Date, growTimeSeconds: number, harvest_count: number, harvest_count_max: number): boolean {
+  static checkCanHarvest(createdAt: Date, growTimeSeconds: number, harvest_count: number, farmConfig :typeof FARM_CONFIG): boolean {
     const grown = this.calculateGrowRemain(createdAt, growTimeSeconds) <= 0;
-     if (harvest_count_max === FARM_CONFIG.PLANT.UNLIMITED) {
-       return grown;
-     }
-    const remainingHarvest = harvest_count_max - (harvest_count ?? 0);
+    if (!farmConfig.PLANT.ENABLE_LIMIT) {
+      return grown;
+    }
+    const remainingHarvest = farmConfig.PLANT.MAX_HARVEST - (harvest_count ?? 0);
     return grown && remainingHarvest > 0;
   }
 
-  static checkNeedWater(p: SlotsPlantEntity): boolean {
-    if (this.checkCanHarvest(p.created_at, p.grow_time, p.harvest_count, p.harvest_count_max)) return false;
+  static checkNeedWater(p: SlotsPlantEntity, farmConfig :typeof FARM_CONFIG): boolean {
+    if (this.checkCanHarvest(p.created_at, p.grow_time, p.harvest_count, farmConfig)) return false;
     const { totalWater } = this.calculateCareNeeds(p.grow_time);
     const { nextWaterTime } = this.getNextWaterTime(p);
     const now = new Date();
@@ -81,8 +81,8 @@ export class PlantCareUtils {
       : false;
   }
 
-  static checkHasBug(p: SlotsPlantEntity): boolean {
-    if (this.checkCanHarvest(p.created_at, p.grow_time, p.harvest_count, p.harvest_count_max)) return false;
+  static checkHasBug(p: SlotsPlantEntity, farmConfig :typeof FARM_CONFIG): boolean {
+    if (this.checkCanHarvest(p.created_at, p.grow_time, p.harvest_count, farmConfig)) return false;
     const totalBug = this.calculateCareNeeds(p.grow_time).totalBug;
     const { nextBugTime } = this.getNextBugTime(p);
     const now = new Date();

--- a/src/modules/plant/plant-care.service.ts
+++ b/src/modules/plant/plant-care.service.ts
@@ -1,3 +1,4 @@
+import { FARM_CONFIG } from '@constant/farm.constant';
 import { PlantState } from '@enum';
 import { SlotsPlantEntity } from '@modules/slots-plant/entity/slots-plant.entity';
 
@@ -60,6 +61,9 @@ export class PlantCareUtils {
 
   static checkCanHarvest(createdAt: Date, growTimeSeconds: number, harvest_count: number, harvest_count_max: number): boolean {
     const grown = this.calculateGrowRemain(createdAt, growTimeSeconds) <= 0;
+     if (harvest_count_max === FARM_CONFIG.PLANT.UNLIMITED) {
+       return grown;
+     }
     const remainingHarvest = harvest_count_max - (harvest_count ?? 0);
     return grown && remainingHarvest > 0;
   }

--- a/src/modules/slots-plant/entity/slots-plant.entity.ts
+++ b/src/modules/slots-plant/entity/slots-plant.entity.ts
@@ -107,12 +107,6 @@ export class SlotsPlantEntity {
   harvest_count: number;
 
   @Exclude()
-  @IsInt()
-  @Max(10)
-  @Column({ type: 'int', default: 10 })
-  harvest_count_max: number;
-
-  @Exclude()
   @CreateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;
 

--- a/src/modules/user-clan-stat/entity/user-clan-stat.entity.ts
+++ b/src/modules/user-clan-stat/entity/user-clan-stat.entity.ts
@@ -93,22 +93,6 @@ export class UserClanStatEntity {
   deleted_at: Date;
 
   @ApiProperty({
-    description: 'Number of times the user has harvested plants',
-    type: 'integer',
-    example: 10,
-  })
-  @Column({ type: 'int', default: 0 })
-  harvest_count: number; // number of times the user harvested plants
-
-  @ApiProperty({
-    description: 'Number of times the user has interrupted other players’ harvests',
-    type: 'integer',
-    example: 10,
-  })
-  @Column({ type: 'int', default: 0 })
-  harvest_interrupt_count: number; // number of times the user interrupted harvests
-
-  @ApiProperty({
     description: 'Number of times the user has harvested plants use',
     type: 'integer',
     example: 10,

--- a/src/modules/user-clan-stat/user-clan-stat.service.ts
+++ b/src/modules/user-clan-stat/user-clan-stat.service.ts
@@ -24,7 +24,7 @@ export class UserClanStatService {
 
     score.total_score = (score.total_score ?? 0) + points;
     score.weekly_score = (score.weekly_score ?? 0) + points;
-    score.harvest_count_use += 1;
+    //score.harvest_count_use += 1;
 
     return await this.userClanStatRepo.save(score);
   }

--- a/src/modules/user-clan-stat/user-clan-stat.service.ts
+++ b/src/modules/user-clan-stat/user-clan-stat.service.ts
@@ -19,12 +19,12 @@ export class UserClanStatService {
     private readonly dataSource: DataSource,
   ) {}
 
-  async addScore(userId: string, clanId: string, points: number) {
+  async addScore(userId: string, clanId: string, points: number, isLimited:boolean) {
     const { score } = await this.getOrCreateUserClanStat(userId, clanId);
 
     score.total_score = (score.total_score ?? 0) + points;
     score.weekly_score = (score.weekly_score ?? 0) + points;
-    //score.harvest_count_use += 1;
+    if(isLimited) score.harvest_count_use += 1;
 
     return await this.userClanStatRepo.save(score);
   }
@@ -33,9 +33,7 @@ export class UserClanStatService {
     const { score } = await this.getOrCreateUserClanStat(userId, clanId);
 
     return {
-      harvest_count: score.harvest_count ?? FARM_CONFIG.HARVEST.MAX_HARVEST,
       harvest_count_use: score.harvest_count_use ?? 0,
-      harvest_interrupt_count: score.harvest_interrupt_count ?? FARM_CONFIG.HARVEST.MAX_INTERRUPT,
       harvest_interrupt_count_use: score.harvest_interrupt_count_use ?? 0,
     };
   }
@@ -57,9 +55,7 @@ export class UserClanStatService {
         clan_id: clanId,
         total_score: 0,
         weekly_score: 0,
-        harvest_count: FARM_CONFIG.HARVEST.MAX_HARVEST,
         harvest_count_use: 0,
-        harvest_interrupt_count: FARM_CONFIG.HARVEST.MAX_INTERRUPT,
         harvest_interrupt_count_use: 0,
       });
       await this.userClanStatRepo.save(score);

--- a/src/types/game.type.ts
+++ b/src/types/game.type.ts
@@ -78,7 +78,6 @@ export class FarmSlotState extends Schema {
   @type('string')  harvestingBy?: string;
   @type('number') harvestEndTime: number = 0;
   @type('number') harvest_count: number = 0;
-  @type('number') harvest_count_max: number = 10;
 }
 
 export interface WithdrawMezonPayload


### PR DESCRIPTION
- Play on mobile => could become a Product because it's separate from desktop
- The new Amazon layout overlaps the chat input; maybe move it a bit higher
- Block spam text -> If possible, after spamming 3 times within 5 seconds, there should be a 15-second wait before spamming again
- Issue when pressing to destroy a player -> after a player finishes harvesting, the popup should still appear when pressed
- The layer of the control buttons should be okay; if they're below the player, they can't be pressed - Heart
- Remove the planting and destruction limits
- Reassign plant purchase rights to all PGDs (maximum 5 PGDs)
- Sort plants by harvest points: large > small